### PR TITLE
Attempt to update to the new Mirage / DNS APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,13 @@ _build/
 log
 key_gen.ml
 main.ml
-main.native
-mir-qubes-test
-qubes-skeleton.xl.in
-qubes-skeleton_libvirt.xml
+qubes_skeleton.xl.in
+qubes_skeleton_libvirt.xml
+.merlin
+dune
+dune-project
+dune.build
+dune.config
+mirage-unikernel-qubes_skeleton-xen.opam
+.mirage.config
+myocamlbuild.ml

--- a/.merlin
+++ b/.merlin
@@ -1,3 +1,0 @@
-S .
-B _build
-PKG vchan.xen lwt mirage logs tcpip.arpv4 dns.mirage mirage-qubes mirage-stack-lwt

--- a/README.md
+++ b/README.md
@@ -10,11 +10,12 @@ done automatically by `mirage configure -t qubes`. This repo remains for educati
 The example code queries QubesDB to get the network configuration, resolves "google.com" using its network VM's DNS service and then fetches "http://google.com".
 It also responds provides a qrexec command, which can be invoked from dom0 (or other domains, if you allow it).
 
-To build (ensure you have mirage 3.0.0 or later):
+To build (ensure you have mirage 3.9.0 or later):
 
     $ opam install mirage
     # NB: We specifically target xen to show explicitly the QubesOS setup independently from the mirage automatic configuration
     $ mirage configure -t xen   
+    $ make depend
     $ make
 
 You can use this with the [test-mirage][] scripts to deploy the unikernel (`qubes_skeleton.xen`) from your development AppVM. e.g.
@@ -96,7 +97,7 @@ You can invoke commands from dom0. e.g.
 
 # LICENSE
 
-Copyright (c) 2016, Thomas Leonard
+Copyright (c) 2020, Thomas Leonard
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
@@ -109,4 +110,4 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 gg
 
 [test-mirage]: https://github.com/talex5/qubes-test-mirage
-[mirage-qubes]: https://github.com/talex5/mirage-qubes
+[mirage-qubes]: https://github.com/mirage/mirage-qubes

--- a/config.ml
+++ b/config.ml
@@ -4,13 +4,15 @@ let main =
   let packages = [
     package "mirage-qubes";
     package "dns";
-    package "mirage-dns";
+    package "dns-client" ~sublibs:["mirage"] ~min:"4.5.0";
   ] in
   foreign
     ~packages
-    "Unikernel.Main" (qubesdb @-> stackv4 @-> time @-> job)
+    "Unikernel.Main" (random @-> qubesdb @-> stackv4 @-> time @-> mclock @-> job)
+
+let stack = qubes_ipv4_stack default_network
 
 let () =
   register "qubes-skeleton" ~argv:no_argv [
-    main $ default_qubesdb $ qubes_ipv4_stack default_network $ default_time
+    main $ default_random $ default_qubesdb $ stack $ default_time $ default_monotonic_clock
   ]


### PR DESCRIPTION
However, this doesn't work. We use ``Resolver.create stack ~nameserver:(`UDP, (nameserver_ip, 53))`` to create the DNS resolver, but the logs show:

```
2020-11-25 16:06:51 -00:00: DBG [ipv4] ip write: mtu is 1500, hdr_len is 20, size 28 payload len 0, needed_bytes 48
2020-11-25 16:06:51 -00:00: DBG [pcb] process-reset: [channels=0 listens=0 connects=1]
2020-11-25 16:06:51 -00:00: DBG [pcb] Refused connection to 10.139.1.1:53
2020-11-25 16:06:51 -00:00: ERR [dns_client_mirage] error connecting to nameserver connection attempt was refused
```

Which looks a lot like it ignored us and tried to use TCP instead.

A comment here points in the same direction: https://github.com/mirage/qubes-mirage-firewall/blob/cfe122592df6c6bdab7c5d322e7b26a52e77be4e/test/unikernel.ml#L348

/cc @hannesm 